### PR TITLE
Added a "warmup" grace period.

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/AutoScaling.scala
@@ -72,6 +72,7 @@ object AutoScaling  extends DeploymentType with S3AclParams {
   )
   val secondsToWait = Param("secondsToWait", "Number of seconds to wait for instances to enter service").default(15 * 60)
   val healthcheckGrace = Param("healthcheckGrace", "Number of seconds to wait for the AWS api to stabilise").default(20)
+  val warmupGrace = Param("warmupGrace", "Number of seconds to wait for the instances in the load balancer to warm up").default(1)
 
   def perAppActions = {
     case "deploy" => (pkg) => (lookup, parameters, stack) => {
@@ -83,6 +84,8 @@ object AutoScaling  extends DeploymentType with S3AclParams {
         TagCurrentInstancesWithTerminationTag(pkg, parameters.stage, stack),
         DoubleSize(pkg, parameters.stage, stack),
         HealthcheckGrace(healthcheckGrace(pkg) * 1000),
+        WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
+        WarmupGrace(warmupGrace(pkg) * 1000),
         WaitForStabilization(pkg, parameters.stage, stack, secondsToWait(pkg) * 1000),
         CullInstancesWithTerminationTag(pkg, parameters.stage, stack),
         ResumeAlarmNotifications(pkg, parameters.stage, stack)

--- a/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/AutoScalingTest.scala
@@ -29,6 +29,8 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       DoubleSize(p, PROD, UnnamedStack),
       HealthcheckGrace(20000),
       WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000),
+      WarmupGrace(1000),
+      WaitForStabilization(p, PROD, UnnamedStack, 15 * 60 * 1000),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack),
       ResumeAlarmNotifications(p, PROD, UnnamedStack)
     ))
@@ -38,7 +40,8 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
     val data: Map[String, JValue] = Map(
       "bucket" -> "asg-bucket",
       "secondsToWait" -> 3 * 60,
-      "healthcheckGrace" -> 30
+      "healthcheckGrace" -> 30,
+      "warmupGrace" -> 20
     )
 
     val app = Seq(App("app"))
@@ -52,6 +55,8 @@ class AutoScalingTest extends FlatSpec with ShouldMatchers {
       TagCurrentInstancesWithTerminationTag(p, PROD, UnnamedStack),
       DoubleSize(p, PROD, UnnamedStack),
       HealthcheckGrace(30000),
+      WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000),
+      WarmupGrace(20000),
       WaitForStabilization(p, PROD, UnnamedStack, 3 * 60 * 1000),
       CullInstancesWithTerminationTag(p, PROD, UnnamedStack),
       ResumeAlarmNotifications(p, PROD, UnnamedStack)


### PR DESCRIPTION
 This leaves the loadbalancer at "double" size for a configurable number of seconds to give the instances time to warm up.

We never realised it, but the 2nd `HealthcheckGrace` (recently removed) was fulfilling this function for us, hence crash and burn when deploying under load today.

@sihil @philwills (please)