### PR TITLE
SBT assembly as auto-plutgin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
 organization := "com.gu"
 
-scalaVersion in ThisBuild := "2.11.4"
-
+scalaVersion in ThisBuild := "2.11.5"

--- a/magenta-cli/build.sbt
+++ b/magenta-cli/build.sbt
@@ -1,5 +1,3 @@
-import sbtassembly.Plugin._
-import AssemblyKeys._
 import java.util.jar.Attributes
 
 libraryDependencies ++= Seq(
@@ -7,12 +5,10 @@ libraryDependencies ++= Seq(
     "net.databinder" %% "dispatch-http" % "0.8.10"
 )
 
-seq(sbtassembly.Plugin.assemblySettings: _*)
-
 packageOptions += {
     Package.ManifestAttributes(
       Attributes.Name.IMPLEMENTATION_VERSION -> System.getProperty("build.number", "DEV")
     )
 }
 
-jarName in assembly := "magenta.jar"
+assemblyJarName in assembly := s"magenta.jar"

--- a/project/MagentaBuild.scala
+++ b/project/MagentaBuild.scala
@@ -1,7 +1,5 @@
 import sbt._
 import Keys._
-import sbtassembly.Plugin._
-import AssemblyKeys._
 import play.twirl.sbt.Import._
 import com.typesafe.sbt.web.SbtWeb
 import com.gu.riffraff.artifact.RiffRaffArtifact
@@ -27,7 +25,6 @@ object MagentaBuild extends Build {
     .settings( magentaSettings: _* )
     .settings(
       testOptions in Test := Nil,
-      jarName in assembly := "%s.jar" format name,
       TwirlKeys.templateImports ++= Seq(
         "magenta._",
         "deployment._",
@@ -38,7 +35,6 @@ object MagentaBuild extends Build {
     )
 
   val magentaSettings: Seq[Setting[_]] = Seq(
-    scalaVersion := "2.11.5",
     scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps,reflectiveCalls,implicitConversions"),
     version := magentaVersion,
     resolvers += "Guardian Github Releases" at "http://guardian.github.com/maven/repo-releases"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 
 addSbtPlugin("com.gu" % "sbt-teamcity-test-reporting-plugin" % "1.5")
 

--- a/riff-raff/build.sbt
+++ b/riff-raff/build.sbt
@@ -1,5 +1,4 @@
 import play.PlayImport.PlayKeys._
-import sbtassembly.Plugin.AssemblyKeys._
 
 // TODO: Remove sonatype releases resolver
 resolvers ++= Seq(
@@ -29,7 +28,6 @@ libraryDependencies ++= Seq(
 
 riffRaffPackageType := assembly.value
 
-assemblySettings
 mainClass in assembly := Some("play.core.server.NettyServer")
 fullClasspath in assembly += Attributed.blank(playPackageAssets.value)
 
@@ -41,7 +39,7 @@ ivyXML :=
     <exclude org="xpp3"></exclude>
   </dependencies>
 
-mergeStrategy in assembly <<= (mergeStrategy in assembly) {
+assemblyMergeStrategy in assembly <<= (assemblyMergeStrategy in assembly) {
   (old) => {
     case "play/core/server/ServerWithStop.class" => MergeStrategy.first
     case x => old(x)
@@ -57,3 +55,5 @@ fork in Test := false
 lazy val magenta = taskKey[File]("Alias to riffRaffArtifact for TeamCity compatibility")
 
 magenta := riffRaffArtifact.value
+
+assemblyJarName in assembly := s"${name.value}.jar"


### PR DESCRIPTION
The latest version of sbt-assembly works as an auto-plugin which reduces boilerplate. The move to `assemblyProperty in assembly` is a bit ugly mind.