### PR TITLE
Support stage-specific params for cfn deployment types

### DIFF
--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -62,7 +62,7 @@ object CloudFormation extends DeploymentType {
       val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
 
       val globalParams = templateParameters(pkg)
-      val stageParams = stageName.flatMap(stage => templateStageParameters(pkg).lift(stage)).getOrElse(Map())
+      val stageParams = templateStageParameters(pkg).lift(parameters.stage.name).getOrElse(Map())
       val combinedParams = globalParams ++ stageParams
 
       List(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -1,7 +1,7 @@
 package magenta.deployment_type
 
-import magenta.{UnnamedStack, NamedStack}
 import magenta.tasks.{CheckUpdateEventsTask, UpdateCloudFormationTask}
+
 import scalax.file.Path
 
 object CloudFormation extends DeploymentType {
@@ -62,7 +62,7 @@ object CloudFormation extends DeploymentType {
       val fullCloudFormationStackName = cloudFormationStackNameParts.mkString("-")
 
       val globalParams = templateParameters(pkg)
-      val stageParams = templateStageParameters(pkg).lift(parameters.stage.name).getOrElse(Map())
+      val stageParams = templateStageParameters(pkg).lift.apply(parameters.stage.name).getOrElse(Map())
       val combinedParams = globalParams ++ stageParams
 
       List(

--- a/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/CloudFormation.scala
@@ -35,7 +35,18 @@ object CloudFormation extends DeploymentType {
     documentation = "Map of parameter names and values to be passed into template. `Stage` and `Stack` (if `defaultStacks` are specified) will be appropriately set automatically."
   ).default(Map.empty)
   val templateStageParameters = Param[Map[String, Map[String, String]]]("templateStageParameters",
-    documentation = "Like templateParameters, but supports stage-specific configuration."
+    documentation =
+      """Like templateParameters, a map of parameter names and values, but in this case keyed by stage to
+        |support stage-specific configuration. E.g.
+        |
+        |    {
+        |        "CODE": { "apiUrl": "my.code.endpoint", ... },
+        |        "PROD": { "apiUrl": "my.prod.endpoint", ... },
+        |    }
+        |
+        |At deploy time, parameters for the matching stage (if found) are merged into any
+        |templateParameters parameters, with stage-specific values overriding general parameters
+        |when in conflict.""".stripMargin
   ).default(Map.empty)
   val createStackIfAbsent = Param[Boolean]("createStackIfAbsent",
     documentation = "If set to true then the cloudformation stack will be created if it doesn't already exist"

--- a/magenta-lib/src/main/scala/magenta/json/JValueExtractable.scala
+++ b/magenta-lib/src/main/scala/magenta/json/JValueExtractable.scala
@@ -1,7 +1,6 @@
 package magenta.json
 
 import org.json4s._
-import org.json4s.native.JsonMethods._
 
 import scala.reflect.ClassTag
 
@@ -29,14 +28,16 @@ object JValueExtractable {
     def extract(json: JValue) = extractOption(JArray.unapply)(json) map (_.flatMap(jve.extract(_)))
   }
   implicit def MapExtractable[V](implicit jve: JValueExtractable[V]) = new JValueExtractable[Map[String,V]] {
-    def extract(json: JValue) = {
-      val kvs: List[(String, Option[V])] = for {
-        JObject(fields) <- json
+    def extract(json: JValue): Option[Map[String, V]] = {
+      val JObject(fields) = json
+
+      val kvs = for {
         field <- fields
       } yield {
         val JField(k, v) = field
         k -> jve.extract(v)
       }
+
       if (kvs.isEmpty || !kvs.forall{case (_, x) => x.isDefined}) None
       else Some(Map(kvs: _*).mapValues(_.get))
     }

--- a/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/UpdateCloudFormationTask.scala
@@ -8,10 +8,14 @@ import com.amazonaws.services.cloudformation.model._
 import scalax.file.Path
 import collection.convert.wrapAsScala._
 
-case class UpdateCloudFormationTask(cloudFormationStackName: String, template: Path,
-                                    parameters: Map[String, String], stage: Stage, stack: Stack,
-                                    createStackIfAbsent:Boolean)
-                                   (implicit val keyRing: KeyRing) extends Task {
+case class UpdateCloudFormationTask(
+  cloudFormationStackName: String,
+  template: Path,
+  parameters: Map[String, String],
+  stage: Stage,
+  stack: Stack,
+  createStackIfAbsent:Boolean)(implicit val keyRing: KeyRing) extends Task {
+
   def execute(stopFlag: => Boolean) = if (!stopFlag) {
     val requiredParameters = CloudFormation.validateTemplate(template.string).getParameters.map(_.getParameterKey)
 


### PR DESCRIPTION
Introduces a new property `templateStageParameters` which supports stage-specific parameters. Currently parameters must be the same across stages, which is somewhat limiting.

Riff Raff will look for a key in the property's map matching the stage of the deployment. If found, it will merge the contained parameters into `templateParameters` (the global parameters if you like), with
stage-specific keys overriding global ones in case of collision.

@philwills @sihil what are your thoughts on this? Happy to discuss.