### PR TITLE
Allow riffraff uploads for identity account

### DIFF
--- a/cloudformation/riffraff.template
+++ b/cloudformation/riffraff.template
@@ -8,7 +8,8 @@
           "arn:aws:iam::743583969668:root",
           "arn:aws:iam::308506855511:root",
           "arn:aws:iam::865473395570:root",
-	  "arn:aws:iam::021353022223:root"
+          "arn:aws:iam::021353022223:root",
+          "arn:aws:iam::942464564246:root"
         ]
       }
     }


### PR DESCRIPTION
Grant access to identity account for uploading to riffraff S3 buckets.