### PR TITLE
Allow Discussion account access to RiffRaff S3 bucket

### DIFF
--- a/cloudformation/riffraff.template
+++ b/cloudformation/riffraff.template
@@ -3,6 +3,7 @@
     "Constants": {
       "AccountPrincipalsWithAccess" : {
         "Value": [
+          "arn:aws:iam::082944406014:root",
           "arn:aws:iam::163592447864:root",
           "arn:aws:iam::642631414762:root",
           "arn:aws:iam::743583969668:root",


### PR DESCRIPTION
We want to try uploading our own artefacts to the bucket.