### PR TITLE
Lambda deployment type

### DIFF
--- a/magenta-lib/build.sbt
+++ b/magenta-lib/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
     "org.bouncycastle" % "bcpg-jdk16" % "1.46",
     "com.decodified" %% "scala-ssh" % "0.7.0" exclude ("org.bouncycastle", "bcpkix-jdk15on"),
     "ch.qos.logback" % "logback-classic" % "1.1.2",
-    "com.amazonaws" % "aws-java-sdk" % "1.9.14",
+    "com.amazonaws" % "aws-java-sdk" % "1.10.35",
     "org.scalatest" %% "scalatest" % "2.2.3" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",

--- a/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/DeploymentType.scala
@@ -51,7 +51,7 @@ trait DeploymentType {
 object DeploymentType {
   def all: Seq[DeploymentType] = Seq(
     ElasticSearch, S3, AutoScaling, ExecutableJarWebapp, JettyWebapp, ResinWebapp, FileCopy, Django, Fastly,
-    UnzipToDocroot, CloudFormation, RPM, NativePackagerWebapp
+    UnzipToDocroot, CloudFormation, RPM, NativePackagerWebapp, Lambda
   )
 }
 

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -8,14 +8,14 @@ object Lambda extends DeploymentType  {
   val name = "aws-lambda"
   val documentation =
     """
-      |Provides one deploy action, `updateLambda`, that runs Lambda Update Function Code using the package file which should be a single file named lambda.zip.
+      |Provides one deploy action, `updateLambda`, that runs Lambda Update Function Code using the package files which can be specified per stage.
     """.stripMargin
   
 
   //required configuration, you cannot upload without setting these
   val functions = Param[Map[String, Map[String, String]]]("functions",
     documentation =
-      """Map of Stage to Lambda function names.
+      """Map of Stage to Lambda functions. 'filename' field is optional and if not specified defaults to lambda.zip
         |e.g.
         |        "functions": {
         |          "CODE": {

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -1,6 +1,7 @@
 package magenta.deployment_type
 
 import java.io.File
+import magenta.MessageBroker
 import magenta.tasks.UpdateLambda
 
 object Lambda extends DeploymentType  {
@@ -29,7 +30,10 @@ object Lambda extends DeploymentType  {
       val fNames = functionNames(pkg)
       val stage = parameters.stage.name
       val fName = fNames get stage
-      assert(fName.isDefined, s"functionName must be defined for stage $stage")
+      fName match{
+        case None => MessageBroker.fail(s"functionName must be defined for stage $stage")
+        case Some(fName) => List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), fName))
+      }
     List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), fName.get))
 
     }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -18,8 +18,9 @@ object Lambda extends DeploymentType  {
     case "updateLambda" => (pkg) => (resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val fName = functionName(pkg)
+      val stage = parameters.stage.name
       assert(functionName.get(pkg).isDefined, "functionName must be defined")
-    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), s"$fName-${parameters.stage}"))
+    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), s"$fName-$stage"))
 
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -1,9 +1,9 @@
 package magenta.deployment_type
 
 import java.io.File
-import magenta.tasks.{UpdateLambda, Lambda}
+import magenta.tasks.UpdateLambda
 
-object Lambda extends DeploymentType with S3AclParams  {
+object Lambda extends DeploymentType  {
   val name = "aws-lambda"
   val documentation =
     """
@@ -17,8 +17,9 @@ object Lambda extends DeploymentType with S3AclParams  {
   def perAppActions = {
     case "updateLambda" => (pkg) => (resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      assert(functionName.get(pkg).isDefined, "functionName must be defined"))
-  List(UpdateLambda)
+      val fName = functionName(pkg)
+      assert(functionName.get(pkg).isDefined, "functionName must be defined")
+    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), fName))
 
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -7,20 +7,30 @@ object Lambda extends DeploymentType  {
   val name = "aws-lambda"
   val documentation =
     """
-      |Provides one deploy action, `updateLambda`, that runs Lambda Update Function Code using the package file which should be a single .zip file.
+      |Provides one deploy action, `updateLambda`, that runs Lambda Update Function Code using the package file which should be a single file named lambda.zip.
     """.stripMargin
   
 
   //required configuration, you cannot upload without setting these
-  val functionName = Param[String]("functionName", "Lambda function name")
+  val functionNames = Param[Map[String, String]]("functionNames",
+    documentation =
+      """Map of Stage to Lambda function names.
+        |e.g.
+        |        "functionNames": {
+        |          "CODE": 'myLambda-CODE',
+        |          "PROD": 'myLambda-PROD'
+        |        }
+      """.stripMargin
+  ).default(Map.empty)
 
   def perAppActions = {
     case "updateLambda" => (pkg) => (resourceLookup, parameters, stack) => {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
-      val fName = functionName(pkg)
+      val fNames = functionNames(pkg)
       val stage = parameters.stage.name
-      assert(functionName.get(pkg).isDefined, "functionName must be defined")
-    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), s"$fName-$stage"))
+      val fName = fNames get stage
+      assert(fName.isDefined, s"functionName must be defined for stage $stage")
+    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), fName.get))
 
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -19,7 +19,7 @@ object Lambda extends DeploymentType  {
       implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
       val fName = functionName(pkg)
       assert(functionName.get(pkg).isDefined, "functionName must be defined")
-    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), fName))
+    List(UpdateLambda(new File(pkg.srcDir.getPath + "/lambda.zip"), s"$fName-${parameters.stage}"))
 
     }
   }

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -1,0 +1,25 @@
+package magenta.deployment_type
+
+import java.io.File
+import magenta.tasks.{UpdateLambda, Lambda}
+
+object Lambda extends DeploymentType with S3AclParams  {
+  val name = "aws-lambda"
+  val documentation =
+    """
+      |Provides one deploy action, `updateLambda`, that runs Lambda Update Function Code using the package file which should be a single .zip file.
+    """.stripMargin
+  
+
+  //required configuration, you cannot upload without setting these
+  val functionName = Param[String]("functionName", "Lambda function name")
+
+  def perAppActions = {
+    case "updateLambda" => (pkg) => (resourceLookup, parameters, stack) => {
+      implicit val keyRing = resourceLookup.keyRing(parameters.stage, pkg.apps.toSet, stack)
+      assert(functionName.get(pkg).isDefined, "functionName must be defined"))
+  List(UpdateLambda)
+
+    }
+  }
+}

--- a/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
+++ b/magenta-lib/src/main/scala/magenta/deployment_type/Lambda.scala
@@ -15,8 +15,9 @@ object Lambda extends DeploymentType  {
   //required configuration, you cannot upload without setting these
   val functions = Param[Map[String, Map[String, String]]]("functions",
     documentation =
-      """Map of Stage to Lambda functions. 'filename' field is optional and if not specified defaults to lambda.zip
+      """Map of Stage to Lambda functions. 'name' is the Lambda FunctionName. The 'filename' field is optional and if not specified defaults to lambda.zip
         |e.g.
+        |
         |        "functions": {
         |          "CODE": {
         |           "name": "myLambda-CODE",

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -24,7 +24,7 @@ trait S3 extends AWS {
 }
 
 trait Lambda extends AWS {
-  def client(keyRing: KeyRing) = new AWSLambdaClient(credentials(keyRing))
+  def lambdaClient(keyRing: KeyRing) = new AWSLambdaClient(credentials(keyRing))
   def lambdaUpdateFunctionCodeRequest(functionName: String, file: File): UpdateFunctionCodeRequest = {
 
     val fileSize = file.length

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -24,7 +24,13 @@ trait S3 extends AWS {
 }
 
 trait Lambda extends AWS {
-  def lambdaClient(keyRing: KeyRing) = new AWSLambdaClient(credentials(keyRing))
+
+  def lambdaClient(implicit keyRing: KeyRing) = {
+    val client = new AWSLambdaClient(credentials(keyRing))
+    client.setEndpoint("lambda.eu-west-1.amazonaws.com")
+    client
+  }
+
   def lambdaUpdateFunctionCodeRequest(functionName: String, file: File): UpdateFunctionCodeRequest = {
 
     val fileSize = file.length

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -43,19 +43,6 @@ trait Lambda extends AWS {
   }
 }
 
-object Lambda {
-  def lambdaUpdateFunctionCodeRequest(functionName: String, file: File): UpdateFunctionCodeRequest = {
-
-    val fileSize = file.length
-    val stream = new FileInputStream(file)
-    val buffer = stream.getChannel.map(READ_ONLY, 0, fileSize)
-    val request = new UpdateFunctionCodeRequest
-    request.withFunctionName(functionName)
-    request.withZipFile(buffer)
-    request
-  }
-}
-
 object S3 {
   def putObjectRequest(bucket: String, key: String, file: File, cacheControlHeader: Option[String], contentType: Option[String], publicReadAcl: Boolean) = {
     val metaData = new ObjectMetadata

--- a/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/AWS.scala
@@ -66,8 +66,6 @@ object S3 {
   }
 }
 
-
-
 trait ASG extends AWS {
   def elb: ELB = ELB
 

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -351,7 +351,7 @@ case class UpdateLambda(
 
     val client = lambdaClient(keyRing)
     MessageBroker.verbose(s"Starting update $functionName Lambda")
-    client.updateFunctionCode(Lambda.lambdaUpdateFunctionCodeRequest(functionName, file))
+    client.updateFunctionCode(lambdaUpdateFunctionCodeRequest(functionName, file))
     MessageBroker.verbose(s"Finished update $functionName Lambda")
   }
 

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -341,7 +341,7 @@ case class InstallRpm(host: Host, path: String, noFileDigest: Boolean = false)(i
   override lazy val description = s"$path on ${host.name}"
 }
 
-case class Lambda(
+case class UpdateLambda(
                    file: File,
                    functionName: String)
                  (implicit val keyRing: KeyRing) extends Task with Lambda {
@@ -351,9 +351,9 @@ case class Lambda(
   def execute(stopFlag: =>  Boolean) {
 
     val client = lambdaClient(keyRing)
-    MessageBroker.verbose("Starting update Lambda")
+    MessageBroker.verbose(s"Starting update $functionName Lambda")
     client.updateFunctionCode(Lambda.lambdaUpdateFunctionCodeRequest(functionName, file))
-    MessageBroker.verbose("Finished update Lambda")
+    MessageBroker.verbose(s"Finished update $functionName Lambda")
   }
 
 }

--- a/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
+++ b/magenta-lib/src/main/scala/magenta/tasks/tasks.scala
@@ -162,7 +162,6 @@ case class S3Upload( stack: Stack,
     Option(file.listFiles).map { _.toSeq.flatMap(resolveFiles) } getOrElse (Seq(file)).distinct
 }
 
-
 case class BlockFirewall(host: Host)(implicit val keyRing: KeyRing) extends RemoteShellTask {
   def commandLine = CommandLocator conditional "block-load-balancer"
 }

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -47,41 +47,6 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
     )
   }
 
-  "AWS Lambda" should "have a updateLambda action" in {
-
-    val data: Map[String, JValue] = Map(
-      "functionNames" ->(
-      "CODE" -> "myLambda"
-        )
-    )
-
-    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", new File("/tmp/packages"))
-
-    Lambda.perAppActions("updateLambda")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
-      List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
-    ))
-
-  }
-
-  it should "throw an AssertionError if a required mapping is missing" in {
-    val badData: Map[String, JValue] = Map(
-      "functionNames" ->(
-        "BADSTAGE" -> "myInvalidStageLambda"
-        )
-
-    )
-
-    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", new File("/tmp/packages"))
-
-    val thrown = the[AssertionError] thrownBy {
-      Lambda.perAppActions("updateLambda")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
-        List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
-        ))
-    }
-
-    thrown.getMessage should equal ("assertion failed: functionName must be defined for stage CODE")
-  }
-
   it should "take a pattern list for cache control" in {
     val data: Map[String, JValue] = Map(
       "bucket" -> "bucket-1234",
@@ -99,6 +64,39 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
           List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
       )
     )
+  }
+
+  "AWS Lambda" should "have a updateLambda action" in {
+
+    val data: Map[String, JValue] = Map(
+      "functionNames" ->(
+        "CODE" -> "myLambda"
+        )
+    )
+
+    val p = DeploymentPackage("myapp", Seq.empty, data, "aws-lambda", new File("/tmp/packages"))
+
+    Lambda.perAppActions("updateLambda")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+      List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
+      ))
+  }
+
+  it should "throw an AssertionError if a required mapping is missing" in {
+    val badData: Map[String, JValue] = Map(
+      "functionNames" ->(
+        "BADSTAGE" -> "myLambda"
+        )
+    )
+
+    val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", new File("/tmp/packages"))
+
+    val thrown = the[AssertionError] thrownBy {
+      Lambda.perAppActions("updateLambda")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+        List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
+        ))
+    }
+
+    thrown.getMessage should equal ("assertion failed: functionName must be defined for stage CODE")
   }
 
   "executable web app package type" should "have a default user of jvmuser" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -58,9 +58,9 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("myapp", Seq.empty, data, "aws-s3", new File("/tmp/packages/static-files"))
 
-    S3.perAppActions("uploadStaticFiles")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
+    S3.perAppActions("uploadStaticFiles")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be(
       List(
-        S3Upload(UnnamedStack, Stage("CODE"),"bucket-1234",new File("/tmp/packages/static-files"),
+        S3Upload(UnnamedStack, Stage("CODE"), "bucket-1234", new File("/tmp/packages/static-files"),
           List(PatternValue("^sub", "no-cache"), PatternValue(".*", "public; max-age:3600")))
       )
     )
@@ -81,7 +81,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
       ))
   }
 
-  it should "throw an AssertionError if a required mapping is missing" in {
+  it should "throw an exception if a required mapping is missing" in {
     val badData: Map[String, JValue] = Map(
       "functionNames" ->(
         "BADSTAGE" -> "myLambda"
@@ -90,13 +90,13 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
 
     val p = DeploymentPackage("myapp", Seq.empty, badData, "aws-lambda", new File("/tmp/packages"))
 
-    val thrown = the[AssertionError] thrownBy {
+    val thrown = the[FailException] thrownBy {
       Lambda.perAppActions("updateLambda")(p)(lookupSingleHost, parameters(Stage("CODE")), UnnamedStack) should be (
         List(UpdateLambda(new File("/tmp/packages/lambda.zip"), "myLambda")
         ))
     }
 
-    thrown.getMessage should equal ("assertion failed: functionName must be defined for stage CODE")
+    thrown.getMessage should equal ("functionName must be defined for stage CODE")
   }
 
   "executable web app package type" should "have a default user of jvmuser" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -69,8 +69,10 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
   "AWS Lambda" should "have a updateLambda action" in {
 
     val data: Map[String, JValue] = Map(
-      "functionNames" ->(
-        "CODE" -> "myLambda"
+      "functions" ->(
+        "CODE" -> {
+         "name" -> "myLambda"
+        }
         )
     )
 
@@ -83,8 +85,9 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
 
   it should "throw an exception if a required mapping is missing" in {
     val badData: Map[String, JValue] = Map(
-      "functionNames" ->(
-        "BADSTAGE" -> "myLambda"
+      "functions" ->(
+        "BADSTAGE" -> {
+          "name" -> "myLambda"}
         )
     )
 
@@ -96,7 +99,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
         ))
     }
 
-    thrown.getMessage should equal ("functionName must be defined for stage CODE")
+    thrown.getMessage should equal ("Function not defined for stage CODE")
   }
 
   "executable web app package type" should "have a default user of jvmuser" in {

--- a/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
+++ b/magenta-lib/src/test/scala/magenta/deployment_type/DeploymentTypeTest.scala
@@ -71,7 +71,7 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
     val data: Map[String, JValue] = Map(
       "functions" ->(
         "CODE" -> {
-         "name" -> "myLambda"
+          "name" -> "myLambda"
         }
         )
     )
@@ -87,7 +87,8 @@ class DeploymentTypeTest extends FlatSpec with Matchers {
     val badData: Map[String, JValue] = Map(
       "functions" ->(
         "BADSTAGE" -> {
-          "name" -> "myLambda"}
+          "name" -> "myLambda"
+        }
         )
     )
 


### PR DESCRIPTION
Adds a deployment type `aws-lambda` which provides one deploy action, `updateLambda`, that runs Lambda Update Function Code using the package files which can be specified per stage.

CC @guardian/discussion @philwills 